### PR TITLE
Add support for ranges in subroutines

### DIFF
--- a/src/measure/dwarf/types.rs
+++ b/src/measure/dwarf/types.rs
@@ -11,20 +11,22 @@ pub type ObjectLocationMap = HashMap<Name, MemoryLocation>;
 pub struct Subroutine {
     /// The demangled name of the subroutine
     pub name: String,
-    /// The starting address of this subroutine
-    pub low_pc: u64,
-    /// The ending address of this subroutine
-    pub high_pc: u64,
+    /// List of ranges of starting and ending addresses where
+    /// this subroutine is used (low_pc, high_pc)
+    pub ranges: Vec<(u64, u64)>,
 }
 
 impl Subroutine {
-    /// Checks if `address` is inside this subroutine's range.
-    pub fn address_in_range(&self, address: u64) -> bool {
-        (self.low_pc <= address) && (address <= self.high_pc)
-    }
-    /// Checks if this subroutine is within `range`
-    pub fn in_range(&self, range: std::ops::Range<u64>) -> bool {
-        range.contains(&self.low_pc) && range.contains(&self.high_pc)
+    /// Checks if `address` is inside this subroutine's range. Returns
+    /// the range if that is the case.
+    pub fn range_from_address(&self, address: u64) -> Option<(u64, u64)> {
+        let mut res: Option<(u64, u64)> = None;
+        for (low_pc, high_pc) in &self.ranges {
+            if (low_pc <= &address) && (&address <= high_pc) {
+                res = Some((*low_pc, *high_pc));
+            }
+        }
+        res
     }
 }
 

--- a/src/measure/hardware/mod.rs
+++ b/src/measure/hardware/mod.rs
@@ -110,7 +110,11 @@ fn read_breakpoints(
                         // Need to increment with 2 here. Because the last instruction of the
                         // vcell function will overwrite `r0` and we need to step over it.
                         // Then overwrite `r0` ourselves!
-                        current_hw_bkpt = current_vcell.high_pc as u32 + 2;
+                        if current_vcell.ranges.is_empty() {
+                            return Err(anyhow!("Subroutine has no address ranges"));
+                        }
+                        let (_, high_pc) = current_vcell.ranges[0];
+                        current_hw_bkpt = high_pc as u32 + 2;
                         core.set_hw_breakpoint(current_hw_bkpt)?;
                     }
 


### PR DESCRIPTION
# Proposed changes
* Add support for multiple ranges in subroutines which will result in fewer unknown values when measuring

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- All commands have been tested on actual hardware

# Related issue
Does fix some parts in #42 

# Checkboxes
- [x] I have run the unit tests with `cargo test`
- [x] I formatted the changes with `cargo fmt`
