### PR TITLE
Add verbosity option to generate and flash commands for builds

### DIFF
--- a/src/cargo/templates/v0_6.toml
+++ b/src/cargo/templates/v0_6.toml
@@ -14,7 +14,8 @@ optional = true
 
 [patch.crates-io]
 cortex-m = { git = "https://github.com/markhakansson/cortex-m.git", branch = "rauk-0.6.0-alpha.2" }
-cortex-m-rtic = { git = "https://github.com/markhakansson/cortex-m-rtic.git", branch = "rauk-0.6.0-alpha.2" }
+#cortex-m-rtic = { git = "https://github.com/markhakansson/cortex-m-rtic.git", branch = "rauk-0.6.0-alpha.2" }
+cortex-m-rtic = { path = "../cortex-m-rtic" }
 cortex-m-rt = { git = "https://github.com/markhakansson/cortex-m-rt.git", branch = "klee" }
 vcell = { git = "https://github.com/markhakansson/vcell.git", branch = "klee" }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -39,6 +39,9 @@ pub struct GenerateInput {
     /// Generate tests in release mode.
     #[structopt(short, long)]
     pub release: bool,
+    /// Enable verbose output
+    #[structopt(short, long)]
+    pub verbose: bool,
     /// Emit all KLEE errors.
     #[structopt(long)]
     pub emit_all_errors: bool,
@@ -56,6 +59,9 @@ pub struct FlashInput {
     /// Build executable in release mode.
     #[structopt(short, long)]
     pub release: bool,
+    /// Enable verbose output
+    #[structopt(short, long)]
+    pub verbose: bool,
     /// The target architecture to build the executable for.
     #[structopt(short, long)]
     pub target: Option<String>,

--- a/src/flash/mod.rs
+++ b/src/flash/mod.rs
@@ -67,6 +67,10 @@ fn build_replay_harness(
         target_dir.push("debug/");
     }
 
+    if input.verbose {
+        cargo.arg("--verbose");
+    }
+
     let name: String;
     if input.example.is_none() {
         name = input.bin.as_ref().unwrap().to_string();

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -64,11 +64,14 @@ fn build_test_harness(
         target_dir.push("examples/");
     }
 
+    if input.verbose {
+        cargo.arg("--verbose");
+    }
+
     cargo
         .args(&["--features", "klee-analysis"])
         .args(&["--manifest-path", cargo_path.to_str().unwrap()])
         .args(&["--target", DEFAULT_KLEE_TARGET])
-        //.arg("--message-format=json")
         .arg("--")
         // ignore linking
         .args(&["-C", "linker=true"])


### PR DESCRIPTION
# Proposed changes
* Add verbosity option for generate and flash to get build information

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- All commands have been tested manually on hardware

# Related issue
Fixes #

# Checkboxes
- [x] I have run the unit tests with `cargo test`
- [x] I formatted the changes with `cargo fmt`
