### PR TITLE
Add missing dependency to template

### DIFF
--- a/src/cargo/templates/v0_6.toml
+++ b/src/cargo/templates/v0_6.toml
@@ -8,6 +8,9 @@ git = "https://github.com/markhakansson/klee-rs.git"
 version = "0.1"
 optional = true
 
+[dependencies.cortex-m-rt]
+version = "0.6"
+
 [dependencies.vcell]
 version = "0.1.3"
 optional = true


### PR DESCRIPTION
# Proposed changes
* Add `cortex-m-rt` to template. If not present in the user's Cargo.toml then Rauk will throw errors.

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- Manually tested with all commands on rauk-example

# Related issue
Fixes #

# Checkboxes
- [x] I have run the unit tests with `cargo test`
- [x] I formatted the changes with `cargo fmt`
