### PR TITLE
Move output to target directory

### DIFF
--- a/src/cargo/mod.rs
+++ b/src/cargo/mod.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result};
 use cargo_toml::Manifest;
-use std::fs::{copy, write};
+use std::fs::{copy, rename, write};
 use std::path::PathBuf;
 use toml;
 
@@ -47,7 +47,7 @@ pub fn backup_original_cargo_files(project_dir: &PathBuf) -> Result<()> {
     })?;
 
     if paths.cargo_lock.exists() {
-        copy(&paths.cargo_lock, &paths.lock_backup).with_context(|| {
+        rename(&paths.cargo_lock, &paths.lock_backup).with_context(|| {
             format!(
                 "Could not backup {:?} to {:?}",
                 &paths.cargo_lock, &paths.lock_backup

--- a/src/cargo/mod.rs
+++ b/src/cargo/mod.rs
@@ -4,6 +4,7 @@ use std::fs::{copy, write};
 use std::path::PathBuf;
 use toml;
 
+const CARGO_TOML: &str = "Cargo.toml";
 /// Name of the Rauk Cargo.toml
 pub const RAUK_CARGO_TOML: &str = ".rauk_cargo.toml";
 /// Name of the backup of the original Cargo.toml
@@ -21,7 +22,7 @@ pub fn backup_original_cargo_toml(project_dir: &PathBuf) -> Result<()> {
 
 fn get_cargo_and_backup_path(project_dir: &PathBuf) -> (PathBuf, PathBuf) {
     let mut cargo_path = project_dir.clone();
-    cargo_path.push("Cargo.toml");
+    cargo_path.push(CARGO_TOML);
     let mut backup_path = project_dir.clone();
     backup_path.push(ORIGINAL_CARGO_COPY);
     (cargo_path, backup_path)
@@ -29,7 +30,7 @@ fn get_cargo_and_backup_path(project_dir: &PathBuf) -> (PathBuf, PathBuf) {
 
 fn get_cargo_and_rauk_path(project_dir: &PathBuf) -> (PathBuf, PathBuf) {
     let mut cargo_path = project_dir.clone();
-    cargo_path.push("Cargo.toml");
+    cargo_path.push(CARGO_TOML);
     let mut rauk_path = project_dir.clone();
     rauk_path.push(RAUK_CARGO_TOML);
     (cargo_path, rauk_path)
@@ -58,7 +59,7 @@ pub fn update_custom_cargo_toml(project_dir: &PathBuf) -> Result<()> {
     rauk_path.push(RAUK_CARGO_TOML);
 
     let mut cargo_path = project_dir.clone();
-    cargo_path.push("Cargo.toml");
+    cargo_path.push(CARGO_TOML);
 
     let mut user_manifest_copy = Manifest::from_path(&cargo_path)?;
     let template = read_rauk_patch_template()?;

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+use simplelog::*;
+use std::fs::File;
+use std::path::PathBuf;
+
+use crate::metadata;
+
+pub const RAUK_LOG_FILE: &str = "rauk.log";
+
+/// Initializes a terminal and file logger
+pub fn init_logger(project_dir: &PathBuf, verbose: bool) -> Result<()> {
+    let mut log_output = project_dir.clone();
+    log_output.push(metadata::RAUK_OUTPUT_DIR);
+    let _ = std::fs::create_dir_all(&log_output);
+    log_output.push(RAUK_LOG_FILE);
+
+    let log_level = match verbose {
+        true => LevelFilter::Info,
+        false => LevelFilter::Warn,
+    };
+
+    CombinedLogger::init(vec![
+        TermLogger::new(
+            log_level,
+            Config::default(),
+            TerminalMode::Mixed,
+            ColorChoice::Auto,
+        ),
+        WriteLogger::new(
+            LevelFilter::Warn,
+            Config::default(),
+            File::create(log_output).unwrap(),
+        ),
+    ])?;
+
+    Ok(())
+}

--- a/src/measure/mod.rs
+++ b/src/measure/mod.rs
@@ -109,7 +109,7 @@ pub fn wcet_measurement(
         .context("Could not complete the analysis of measurement data")?;
     println!("{:#?}", traces);
 
-    let output_path = save_traces_to_directory(&traces, &metadata.project_directory)?;
+    let output_path = save_traces_to_directory(&traces, &metadata.rauk_output_directory)?;
 
     Ok(Some(output_path))
 }

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -68,12 +68,24 @@ pub fn settings_file_exists(project_dir: &PathBuf) -> bool {
 }
 
 /// Load settings from project directory if it exists.
-pub fn load_settings_from_dir(project_dir: &PathBuf) -> Result<RaukSettings> {
+fn load_settings_from_dir(project_dir: &PathBuf) -> Result<RaukSettings> {
     let mut rauk_config_path = project_dir.clone();
     rauk_config_path.push(RAUK_CONFIG_TOML);
     let mut file = File::open(rauk_config_path)?;
     let mut contents = String::new();
     file.read_to_string(&mut contents)?;
     let settings: RaukSettings = toml::from_str(&contents)?;
+    Ok(settings)
+}
+
+/// Loads settings from file if it exists, otherwise creates an empty
+/// settings struct.
+pub fn load_settings(project_dir: &PathBuf) -> Result<RaukSettings> {
+    let settings = if settings_file_exists(&project_dir) {
+        load_settings_from_dir(&project_dir)?
+    } else {
+        RaukSettings::new()
+    };
+
     Ok(settings)
 }


### PR DESCRIPTION
# Proposed changes
* Move output to target directory (all rauk output and metadata)
* Move some functions in main to other parts
* Backup `Cargo.lock` and move it. So you don't have to delete it every time rust-analyzer builds your project
* Symlink `klee-last` to rauk output directory for easy access
* Some smaller bug fixes I don't remember

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- All commands tested manually on hardware

# Related issue
Fixes #53, fixes #63 

# Checkboxes
- [x] I have run the unit tests with `cargo test`
- [x] I formatted the changes with `cargo fmt`
