### PR TITLE
Add halt timeout override as flag and setting

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -101,6 +101,9 @@ pub struct FlashInput {
     /// The name of the chip to flash to.
     #[structopt(short, long)]
     pub chip: Option<String>,
+    /// How many seconds to wait for core to halt before panicking. Default 10s.
+    #[structopt(short, long)]
+    pub halt_timeout: Option<u64>,
 }
 
 impl FlashInput {
@@ -123,6 +126,9 @@ pub struct MeasureInput {
     /// The name of the chip to flash to.
     #[structopt(short, long)]
     pub chip: Option<String>,
+    /// How many seconds to wait for core to halt before panicking. Default 10s.
+    #[structopt(short, long)]
+    pub halt_timeout: Option<u64>,
 }
 
 impl MeasureInput {

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -7,7 +7,7 @@ use probe_rs::flashing::{download_file, Format};
 use std::path::PathBuf;
 use std::process::{Command, ExitStatus};
 
-const HALT_TIMEOUT_SECONDS: u64 = 5;
+const DEFAULT_HALT_TIMEOUT_SECONDS: u64 = 5;
 
 /// Builds the replay harness and flashes it to the target hardware.
 /// Returns the path to the built executable.
@@ -23,6 +23,9 @@ pub fn flash_to_target(
 
     let mut updated_input = input.clone();
     updated_input.get_missing_input(settings);
+    let halt_timeout = updated_input
+        .halt_timeout
+        .unwrap_or(DEFAULT_HALT_TIMEOUT_SECONDS);
 
     build_replay_harness(&updated_input, &mut cargo_path, &mut target_dir)
         .context("Failed to build the replay harness")?;
@@ -40,7 +43,7 @@ pub fn flash_to_target(
 
     // Reset the core and halt
     let mut core = session.core(0)?;
-    core.reset_and_halt(std::time::Duration::from_secs(HALT_TIMEOUT_SECONDS))?;
+    core.reset_and_halt(std::time::Duration::from_secs(halt_timeout))?;
 
     Ok(target_dir)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ fn main() -> Result<()> {
         // Patch the project's Cargo.toml
         if !opts.no_patch {
             cargo::backup_original_cargo_files(&project_dir)?;
-            info!("User Cargo.toml backed up");
+            info!("User Cargo files backed up");
             cargo::update_custom_cargo_toml(&project_dir)?;
             cargo::change_cargo_toml_to_custom(&project_dir)?;
             info!("Custom Cargo.toml patched");
@@ -77,17 +77,20 @@ fn match_cli_opts(
 
     match &opts.cmd {
         Command::Generate(g) => {
+            info!("Executing generate command");
             let path = generate::generate_klee_tests(g, &metadata)
                 .context("Failed to execute generate command")?;
             let _ = symlink(&path, &metadata.rauk_output_directory.join("klee-last"));
             metadata.update_output(&g.build, Some(path), &opts.cmd)?;
         }
         Command::Flash(f) => {
+            info!("Executing flash command");
             let path = flash::flash_to_target(f, &settings, &metadata)
                 .context("Failed to execute flash command")?;
             metadata.update_output(&f.build, Some(path), &opts.cmd)?;
         }
         Command::Measure(a) => {
+            info!("Executing measure command");
             let path = measure::wcet_measurement(a, &settings, &metadata)
                 .context("Failed to execute analyze command")?;
             metadata.update_output(&a.build, path, &opts.cmd)?;
@@ -103,7 +106,7 @@ fn post_execution_cleanup(project_dir: &PathBuf, no_patch: bool) -> Result<()> {
     // Restore original Cargo.toml
     if !no_patch {
         cargo::restore_orignal_cargo_files(&project_dir)?;
-        info!("User Cargo.toml restored");
+        info!("User Cargo files restored");
     }
 
     Ok(())

--- a/src/measure/mod.rs
+++ b/src/measure/mod.rs
@@ -102,7 +102,7 @@ pub fn wcet_measurement(
     };
     let mut core = session.core(0)?;
 
-    let measurements = hardware::measure_replay_harness(&mut core, &ktests, &app)
+    let measurements = hardware::measure_replay_harness(input, &mut core, &ktests, &app)
         .context("Could not complete the measurement of the replay harness")?;
 
     let traces = post_measurement_analysis(measurements)

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -99,6 +99,7 @@ impl RaukMetadata {
         let info_path = get_metadata_path(&self.project_directory);
 
         if info_path.exists() {
+            info!("Loading metadata from previous execution");
             let data =
                 std::fs::read_to_string(&info_path).context("Failed to read RaukMetadata")?;
             let output_info: RaukMetadata = serde_json::from_str(&data).with_context(|| {

--- a/src/settings/mod.rs
+++ b/src/settings/mod.rs
@@ -17,6 +17,8 @@ pub struct General {
     pub chip: Option<String>,
     #[serde(default)]
     pub target: Option<String>,
+    #[serde(default)]
+    pub halt_timeout: Option<u64>,
 }
 
 /// Rauk settings file that can be used instead of command input
@@ -44,6 +46,9 @@ impl FlashInput {
             if self.chip.is_none() {
                 self.chip = general.chip.clone();
             }
+            if self.halt_timeout.is_none() {
+                self.halt_timeout = general.halt_timeout.clone();
+            }
         }
     }
 }
@@ -55,6 +60,9 @@ impl MeasureInput {
         if let Some(general) = &settings.general {
             if self.chip.is_none() {
                 self.chip = general.chip.clone();
+            }
+            if self.halt_timeout.is_none() {
+                self.halt_timeout = general.halt_timeout.clone();
             }
         }
     }
@@ -82,8 +90,10 @@ fn load_settings_from_dir(project_dir: &PathBuf) -> Result<RaukSettings> {
 /// settings struct.
 pub fn load_settings(project_dir: &PathBuf) -> Result<RaukSettings> {
     let settings = if settings_file_exists(&project_dir) {
+        info!("Loading user settings from file");
         load_settings_from_dir(&project_dir)?
     } else {
+        info!("No user settings file found");
         RaukSettings::new()
     };
 


### PR DESCRIPTION
# Proposed changes
* Adds halt timeout for probe-rs core override as a CLI flag and setting

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. 

- All commands tested manually on hardware

# Related issue
Fixes #50 

# Checkboxes
- [x] I have run the unit tests with `cargo test`
- [x] I formatted the changes with `cargo fmt`
